### PR TITLE
Fix printing of T48 firmware version

### DIFF
--- a/t48/version.py
+++ b/t48/version.py
@@ -26,7 +26,7 @@ def main():
     print("model: %s" % version["model"])
     print("Dev code: %s" % version["dev_code"])
     print("Serial: %s" % version["serial"])
-    print("FW version: %u.%u" % (version["ver_major"], version["ver_minor"]))
+    print(f"FW version: {version['ver_major']}.{version['ver_minor']:02}")
     print("Manufacture date: %s" % version["date"])
 
     hexdump(version["res00"], indent="res00: ")


### PR DESCRIPTION
The minor version needs to be padded to two digits using a leading zero.

Firmware version 1.07 was being reported as 1.7.
This is confirmed if one looks at the 2 first bytes of a firmware binary,
which encode the minor and major version, respectively.
If one uses xgecuPro on Windows to program a firmware binary with
those leading bytes, it displays the T48 firmware version as "01.07".
I also confirmed that bytes of 0x10 0x01 is displayed as "01.10".